### PR TITLE
Updated span class name 'region' to 'locality' as the website has updated class name to get location of company

### DIFF
--- a/scrapers/clutchco_scraper.py
+++ b/scrapers/clutchco_scraper.py
@@ -48,7 +48,7 @@ class ClutchScraper:
             for domain in company.find_all('a', {'href': re.compile('^http')}):
 
                 try:
-                    countryName = company.find('span', {'class': re.compile('region')}).string
+                    countryName = company.find('span', {'class': re.compile('locality')}).string
 
                     for country in countries.countries:
 


### PR DESCRIPTION
The clutch.co website has changed the class name of the location of the company from 'region' to 'locality'

![Update of clutch.co](https://user-images.githubusercontent.com/70624701/161732678-488ebac2-22c6-425b-a498-8e31164b0523.png)